### PR TITLE
export /std/vector</double> explicitly as the RTT exports it as "array"

### DIFF
--- a/std.orogen
+++ b/std.orogen
@@ -25,5 +25,7 @@ typekit do
     export_types "/float"
     export_types "/double"
     export_types "/std/string"
+    # Yes, RTT has std::vector<double>, so we need to do the same. Thanks guys.
+    export_types "/std/vector</double>"
     export_types "metadata/Component"
 end


### PR DESCRIPTION
Otherwise, components that define e.g. a property of type
std::vector<double> will be for instance able to access it
through corba, but won't be able to log it.
