### PR TITLE
make orogen_metadata optional

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -8,6 +8,6 @@
   <logo>http://</logo>
 
   <depend package="orogen" />
-  <depend package="tools/orogen_metadata" />
+  <depend package="tools/orogen_metadata" optional="1"/>
   <tags>stable</tags>
 </package>

--- a/std.orogen
+++ b/std.orogen
@@ -1,9 +1,6 @@
 name "std"
 version "1.0"
 
-using_library "orogen_metadata"
-import_types_from "orogen_metadata/Metadata.hpp"
-
 typekit do
     Typelib::Registry.add_standard_cxx_types(registry)
     if type_export_policy == :used
@@ -27,5 +24,12 @@ typekit do
     export_types "/std/string"
     # Yes, RTT has std::vector<double>, so we need to do the same. Thanks guys.
     export_types "/std/vector</double>"
-    export_types "metadata/Component"
 end
+
+begin
+    using_library "orogen_metadata"
+    import_types_from "orogen_metadata/Metadata.hpp"
+    export_types "metadata/Component"
+rescue Orocos::TypekitNotFound
+end
+


### PR DESCRIPTION
orogen_metadata is not ready to be released. We therefore need to make
it optional to avoid having to release it along with the
latest fixes to std
