### PR TITLE
adopt to renamed "struct metadata::TaskContext"

### DIFF
--- a/std.orogen
+++ b/std.orogen
@@ -27,5 +27,5 @@ typekit do
     export_types "/std/string"
     # Yes, RTT has std::vector<double>, so we need to do the same. Thanks guys.
     export_types "/std/vector</double>"
-    export_types "metadata/Component"
+    export_types "/metadata/TaskContext"
 end


### PR DESCRIPTION
Related to [this](https://github.com/rock-core/tools-orogen_metadata/pull/2) PR.

What about the [make_orogen_metadata_optional](https://github.com/rock-core/base-orogen-std/tree/make_orogen_metadata_optional)? Its in rock1408, but not in master? And commit-msg states it should not be released...? _scratch_

Signed-off-by: Martin Zenzes martin.zenzes@dfki.de
