### PR TITLE
register include metadata for standard C++ types as well

### DIFF
--- a/std.orogen
+++ b/std.orogen
@@ -6,6 +6,7 @@ import_types_from "orogen_metadata/Metadata.hpp"
 
 typekit do
     Typelib::Registry.add_standard_cxx_types(registry)
+    resolve_registry_includes(registry, Array.new)
     if type_export_policy == :used
         # We assume that, if the caller wants a 'used' type policy, it means he
         # wants partial exports. Move to 'selected'. oroGen would have changed


### PR DESCRIPTION
The include metadata is generated at loading time now. By calling
add_standard_cxx_types we do "load" types but we are not registering
the orogen_include metadata required by orogen (this is a typelib
method). Do so explicitely